### PR TITLE
improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ brew install kubectl
 brew install helm
 ```
 
+Please also make sure you have sufficient memory for Docker, see [Resources](https://docs.docker.com/docker-for-mac/#resources) for how to increase.
+
 ### Linux
 ```bash
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Here are installation instructions for `kubectl`, `kind`, and `helm`:
 
 ### MacOS
 For MacOS, we recommend [Homebrew](https://brew.sh) to make installing these utilities simple.
-```
+```bash
 brew install kind
 brew install kubectl
 brew install helm
 ```
 
 ### Linux
-```
+```bash
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
 && sudo install kubectl /usr/local/bin && rm kubectl
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
@@ -27,7 +27,7 @@ curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64 && sudo ins
 
 To run the demo, simply run `start.sh`:
 
-```
+```bash
 ./start.sh
 ```
 
@@ -40,3 +40,13 @@ This will stand up Elasticsearch, Kibana, Grafana, Prometheus, Fluentd and Teleg
 |Prometheus|[http://localhost:30002](http://localhost:30002)|
 
 Check out the AppScope dashboards in Grafana and Kibana!
+
+For Grafana's login credential, see `grafana.values.yml`
+
+## Clean up
+
+To clean up the demo, simply run `stop.sh`:
+
+```bash
+./stop.sh
+```


### PR DESCRIPTION
just minor improvements for readme:
- add note for increasing docker for mac memory (default is 2Gi which is not enough to run this demo)
- add clean up section
- make scripts blocks as `bash`
