### PR TITLE
Support SCOPE_VER and Sideloading

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+IMAGE="cribl/scope:${SCOPE_VER:-0.6.0}"
 
 whitespace() {
   echo ""
@@ -32,16 +33,21 @@ nodes:
     hostPort: 30004
     protocol: TCP
 EOF
+  if [ -n "$(docker images -q --filter=reference=$IMAGE)" ]; then
+      echo
+      echo "Sideloading $IMAGE image into cluster"
+      kind load docker-image $IMAGE --name scope-k8s-demo
+  fi
   whitespace
 }
 
 scope() {
   echo "Installing scope"
   if [[ $1 == "cribl" ]]; then
-    docker run -it --rm cribl/scope:0.6.0 \
+    docker run -it --rm $IMAGE \
       scope k8s --cribldest cribl-internal:10090 | kubectl apply -f -
   else
-    docker run -it --rm cribl/scope:0.6.0 \
+    docker run -it --rm $IMAGE \
       scope k8s --metricdest tcp://telegraf:8125 --metricformat statsd --eventdest tcp://fluentd:10001 | kubectl apply -f -
   fi
   


### PR DESCRIPTION
This adds support for setting the SCOPE_VER envrionment variable when
running start.sh to specify the image tag for cribl/scope to use like
so.

    $ SCOPE_VER=0.7.0-rc5 ./start.sh cribl

This also adds a step in start.sh to sideload the cribl/scope image into
the cluster if it's found among the local Docker images. For debugging.