### PR TITLE
Update demo to support Appscope 1.3.2

### DIFF
--- a/client-alpine.k8s.yml
+++ b/client-alpine.k8s.yml
@@ -17,5 +17,5 @@ spec:
       containers:
       - name: client-alpine
         image: alpine:latest
-        command: [/scope/ldscope]
-        args: ["/usr/bin/tail", "-F", "/scope/ldscope.log"]
+        command: [/scope/scope]
+        args: ["-z", "/usr/bin/tail", "-F", "/scope/0/libscope.log"]

--- a/grafana.values.yml
+++ b/grafana.values.yml
@@ -5,6 +5,7 @@ adminPassword: scopedemo
 env:
   SCOPE_EVENT_HTTP_HEADER: "(?i)Cookie.*"
   SCOPE_GO_HTTP1: false
+  SCOPE_HOME: "/home/grafana/"
 
 image:
   repository: grafana/grafana

--- a/prometheus.k8s.yml
+++ b/prometheus.k8s.yml
@@ -49,8 +49,8 @@ spec:
     spec:
       containers:
         - image: cribl/scope-k8s-demo-prometheus
-          command: ["/scope/ldscope"]
-          args: ["/opt/prom/prometheus", "--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/opt/prom/console_libraries", "--web.console.templates=/opt/prom/consoles", "--enable-feature=remote-write-receiver"]
+          command: ["/scope/scope"]
+          args: ["-z", "/opt/prom/prometheus", "--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/opt/prom/console_libraries", "--web.console.templates=/opt/prom/consoles", "--enable-feature=remote-write-receiver"]
           imagePullPolicy: IfNotPresent
           name: prometheus
           ports:

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
 USER nobody
 EXPOSE 9090
 WORKDIR /prometheus
-ENTRYPOINT [ "/scope/ldscope", "/opt/prom/prometheus" ]
+ENTRYPOINT [ "/scope/scope", "-z", "/opt/prom/prometheus" ]
 CMD ["--config.file=/etc/prometheus/prometheus.yml", \
     "--storage.tsdb.path=/prometheus", \
     "--web.console.libraries=/opt/prom/console_libraries", \

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-IMAGE="cribl/scope:${SCOPE_VER:-1.0.1}"
+IMAGE="cribl/scope:${SCOPE_VER:-1.3.2}"
 
 whitespace() {
   echo ""


### PR DESCRIPTION
Do not merge it yet.
Updates changes in the setup according to release 1.3.0:
- replace `ldscope` with `scope -z`
- update path of `ldscope.log`
Requires:
- [x] release 1.3.2